### PR TITLE
use 0.6.0-pre as minimum julia version in REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.6-
+julia 0.6.0-pre
 TestSetExtensions


### PR DESCRIPTION
since `struct` syntax wouldn't work in early 0.6.0-dev versions,
the package shouldn't claim to support them